### PR TITLE
Changes to CPS1 and CPS2 CPU speeds for certain roms

### DIFF
--- a/src/burn/drv/capcom/d_cps1.cpp
+++ b/src/burn/drv/capcom/d_cps1.cpp
@@ -17608,8 +17608,10 @@ static INT32 Sf2bhhInit()
 
 static INT32 Sf2hfInit()
 {
-	// runs too fast - slow it down a bit (73.75% of 12MHz as per http://mametesters.org/view.php?id=408)
-	nCPS68KClockspeed = 8850000;
+	// game runs too fast - RN compared MAME/FBA to PCB
+	// RN October 2018 research: adjust excessive speed to 65.83% of 12Mhz as per: https://www.youtube.com/watch?v=HyL87eswe8M
+	
+	nCPS68KClockspeed = 7900000;
 	
 	return DrvInit();
 }

--- a/src/burn/drv/capcom/d_cps2.cpp
+++ b/src/burn/drv/capcom/d_cps2.cpp
@@ -8480,9 +8480,10 @@ static INT32 Ssf2tInit()
 	
 	Ssf2t = 1;
 	
-	// game runs too fast - RN compared MAME to PCB and setting the CPU overclock to 86.49% of 12MHz was the closest match
-	// this value also compares well with PCB recording - https://www.youtube.com/watch?v=m3bnMgrE2y8
-	nCPS68KClockspeed = 10378800;
+	// game runs too fast - RN compared MAME/FBA to PCB
+	// RN October 2018 research: adjust excessive speed to 90.5625% if 12Mhz as per: https://www.youtube.com/watch?v=RafLAkg0Wr4
+	
+	nCPS68KClockspeed = 10867500;
 	
 	nRet = Cps2Init();
 	


### PR DESCRIPTION
RagingNoob (aka RN) With extensive research comparing PCB to emulator drivers, I have concluded the following report based on 2 youtube videos.

CPS1 driver for SF2HF (and variants) rom was running excessively fast in comparison to the original PCB.
This is now corrected in the d_cps1.cpp file with the video to support:
[https://www.youtube.com/watch?v=HyL87eswe8M](url)

CPS2 : SSF2T (and variants) was also requiring a speed adjustment to align frame rendering to closely resemble the original PCB.
This is now corrected in the d_cps2.cpp file with the video to support:
[https://www.youtube.com/watch?v=RafLAkg0Wr4](url)

